### PR TITLE
v0.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0
+          - 1.65.0
           # - stable
           # - beta
           # - nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fafo ]
   pull_request:
     branches: [ master ]
     
@@ -18,26 +18,30 @@ jobs:
       matrix:
         rust:
           - 1.63.0
-          - stable
-          - beta
-          - nightly
-        include:
-          - rust: stable
-            target: thumbv7em-none-eabihf
-          - rust: beta
-            target: thumbv7em-none-eabihf
-          - rust: nightly
-            coverage: 'send'
-            components: llvm-tools
-            target: thumbv7em-none-eabihf
+          # - stable
+          # - beta
+          # - nightly
+        # include:
+          # - rust: stable
+          #   target: thumbv7em-none-eabihf
+          # - rust: beta
+          #   target: thumbv7em-none-eabihf
+          # - rust: nightly
+          #   coverage: 'send'
+          #   components: llvm-tools
+          #   target: thumbv7em-none-eabihf
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
 
       - name: Install ${{ matrix.rust }} toolchain
         run: |
-          rustup toolchain install ${{ matrix.rust }} --profile minimal --target=${{ matrix.target }} --no-self-update
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
           rustup default ${{ matrix.rust }}
+
+      - name: Add target
+        if: ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install ${{ matrix.components }} components
         if: ${{ matrix.components }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,24 +32,22 @@ jobs:
             target: thumbv7em-none-eabihf
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain:  ${{ matrix.rust }}
-          components: ${{ matrix.components }}
-          target:     ${{ matrix.target }}
-          override: true
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --target=${{ matrix.target }} --no-self-update
+          rustup default ${{ matrix.rust }}
+
+      - name: Install ${{ matrix.components }} components
+        if: ${{ matrix.components }}
+        run: rustup component add ${{ matrix.components }}
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install grcov
         if: matrix.coverage == 'send'
-        uses: actions-rs/install@v0.1
-        with:
-          crate: grcov
-          version: latest
-          use-tool-cache: true
+        run: cargo install grcov
 
       - name: Tests
         env:
@@ -98,7 +96,7 @@ jobs:
 
       - name: Upload coverage as artifact
         if: matrix.coverage == 'send'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v7
         with:
           name: lcov.info
           path: ./lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,18 @@ jobs:
       matrix:
         rust:
           - 1.65.0
-          # - stable
-          # - beta
-          # - nightly
-        # include:
-          # - rust: stable
-          #   target: thumbv7em-none-eabihf
-          # - rust: beta
-          #   target: thumbv7em-none-eabihf
+          - stable
+          - beta
+          - nightly
+        include:
+          - rust: stable
+            target: thumbv7em-none-eabihf
+          - rust: beta
+            target: thumbv7em-none-eabihf
           # - rust: nightly
-          #   coverage: 'send'
-          #   components: llvm-tools
-          #   target: thumbv7em-none-eabihf
+            # coverage: 'send'
+            # components: llvm-tools
+            # target: thumbv7em-none-eabihf
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ master, fafo ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
-    
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -26,10 +26,10 @@ jobs:
             target: thumbv7em-none-eabihf
           - rust: beta
             target: thumbv7em-none-eabihf
-          # - rust: nightly
-            # coverage: 'send'
-            # components: llvm-tools
-            # target: thumbv7em-none-eabihf
+          - rust: nightly
+            coverage: 'send'
+            components: llvm-tools
+            target: thumbv7em-none-eabihf
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.6.2
+* Fixed a bug in LhaHeader::read that could cause integer overflow.
+* Fixed a bug in LhaHeader::read that could allocate a huge memory chunk before failing.
+* Added a static assert to prevent compilation on systems with usize < 32-bit.
+* Added missing long_header_len check on lha_level=3 in in LhaHeader::read.
+* Fixed minor warnings.
+* Minimum supported rust version changed to Rust 1.65.
+
 v0.6.1
 * Fixed a bug in LhaV2Decoder::read_temp_tree that might cause a panic on a random bitstream.
 * Deps: bitflags upgraded to 2.5.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/royaltm/rust-delharc"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 exclude = [".github", ".gitignore", "tests/*", "examples/*"]
-rust-version = "1.63"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/royaltm/rust-delharc"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 exclude = [".github", ".gitignore", "tests/*", "examples/*"]
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delharc"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Rafal Michalski <royaltm75@gmail.com>"]
 edition = "2021"
 description = "A library for parsing and extracting files from LHA/LZH archives."

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ compression method features.
 Rust Version
 ------------
 
-`delharc` requires Rustc version 1.63 or greater due to the stabilized [`array::from_fn`](https://doc.rust-lang.org/std/array/fn.from_fn.html) function in this version.
+`delharc` requires Rustc version 1.65 or greater.
 
 License
 -------
@@ -100,4 +100,4 @@ at your option.
 [Coverage Link]: https://coveralls.io/github/royaltm/rust-delharc?branch=master
 [Coverage img]: https://coveralls.io/repos/github/royaltm/rust-delharc/badge.svg?branch=master
 [rustc version link]: https://github.com/royaltm/rust-delharc#rust-version
-[rustc version img]: https://img.shields.io/badge/rustc-1.63+-lightgray.svg
+[rustc version img]: https://img.shields.io/badge/rustc-1.65+-lightgray.svg

--- a/examples/embedded/embedded.rs
+++ b/examples/embedded/embedded.rs
@@ -62,7 +62,9 @@ fn main() -> ! {
   {
       #[no_mangle]
       static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
-      unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
+      // FIXME: MRV >= 1.82.0
+      // unsafe { HEAP.init((&raw mut HEAP_MEM) as usize, HEAP_SIZE) }
+      unsafe { HEAP.init(core::ptr::addr_of_mut!(HEAP_MEM) as usize, HEAP_SIZE) }
   }
 
   let lha_reader = delharc::LhaDecodeReader::new(COMPRESSED_1).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,8 @@ pub(crate) mod bitstream;
 pub(crate) mod statictree;
 
 // Various parsers assume usize has enough bits and will break on < 32-bits.
-const _: usize = (size_of::<usize>() >= size_of::<u32>()) as usize - 1;
+// FIXME: size_of
+const _: usize = (core::mem::size_of::<usize>() >= core::mem::size_of::<u32>()) as usize - 1;
 
 pub use decode::LhaDecodeReader;
 pub use header::{


### PR DESCRIPTION
* Fixed a bug in LhaHeader::read that could cause integer overflow.
* Fixed a bug in LhaHeader::read that could allocate a huge memory chunk before failing.
* Added a static assert to prevent compilation on systems with usize < 32-bit.
* Added missing long_header_len check on lha_level=3 in in LhaHeader::read.
* Fixed minor warnings.
* Minimum supported rust version changed to Rust 1.65.
