### PR TITLE
v0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, foo ]
   pull_request:
     branches: [ master ]
 
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0
+          - 1.93.0
           - stable
           - beta
           - nightly
@@ -27,8 +27,8 @@ jobs:
           - rust: beta
             target: thumbv7em-none-eabihf
           - rust: nightly
-            coverage: 'send'
-            components: llvm-tools
+            # coverage: 'send'
+            # components: llvm-tools
             target: thumbv7em-none-eabihf
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ master, foo ]
+    branches: [ master, devel ]
   pull_request:
     branches: [ master ]
 
@@ -27,8 +27,8 @@ jobs:
           - rust: beta
             target: thumbv7em-none-eabihf
           - rust: nightly
-            # coverage: 'send'
-            # components: llvm-tools
+            coverage: 'send'
+            components: llvm-tools
             target: thumbv7em-none-eabihf
     steps:
       - name: Checkout sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.7.0
+* Rust edition: 2024.
+* Minimum supported rust version changed to Rust 1.93 (slice::assume_init_mut).
+* Deps: bitflags bumped to 2.13.
+* bytemuck added to dependencies.
+* replaced all uses of transmute with modern functions.
+* clippy suggested changes.
+
 v0.6.2
 * Fixed a bug in LhaHeader::read that could cause integer overflow.
 * Fixed a bug in LhaHeader::read that could allocate a huge memory chunk before failing.
@@ -8,7 +16,7 @@ v0.6.2
 
 v0.6.1
 * Fixed a bug in LhaV2Decoder::read_temp_tree that might cause a panic on a random bitstream.
-* Deps: bitflags upgraded to 2.5.
+* Deps: bitflags bumped to 2.5.
 
 v0.6.0
 * no-std is enabled in the absence of the std feature.
@@ -21,17 +29,17 @@ v0.6.0
 * TimestampResult::to_local is only available with std feature.
 * LhaHeader::parse_pathname is only available with std feature.
 * delharc::parse_file is only available with std feature.
-* Deps: bitflags upgraded to 2.4.
+* Deps: bitflags bumped to 2.4.
 * extract_nostd example added to showcase usage of nostd.
 * Embedded example added to test compilation of a no-std target.
 
 v0.5.0
-* Rust edition: 2021
+* Rust edition: 2021.
 * An example added to showcase usage of different reader sources.
 * RingArrayBuf reworked with const generics.
 * dyntree: unsafe transmute replaced with array::from_fn.
 * Minimum supported rust version changed to Rust 1.63 (array::from_fn).
-* Deps: bitflags upgraded to 2.3.
+* Deps: bitflags updated to 2.3.
 * License files added.
 
 v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/royaltm/rust-delharc"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 exclude = [".github", ".gitignore", "tests/*", "examples/*"]
-rust-version = "1.87"
+rust-version = "1.93"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,6 +27,7 @@ lz = []
 chrono = { version = "0.4", default-features = false }
 bitflags = "2.13"
 memchr = { version = "2", default-features = false }
+bytemuck = { version = "1.25", features = ["derive"] }
 
 [dev-dependencies]
 crc-any = { version = "3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/royaltm/rust-delharc"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 exclude = [".github", ".gitignore", "tests/*", "examples/*"]
-rust-version = "1.85"
+rust-version = "1.87"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -25,12 +25,12 @@ lz = []
 
 [dependencies]
 chrono = { version = "0.4", default-features = false }
-bitflags = "2.5"
+bitflags = "2.13"
 memchr = { version = "2", default-features = false }
 
 [dev-dependencies]
-crc-any = { version = "2.5", default-features = false }
-rand = "0.8.5"
+crc-any = { version = "3", default-features = false }
+rand = "0.10.2"
 
 [[example]]
 name = "extract"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "delharc"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Rafal Michalski <royaltm75@gmail.com>"]
-edition = "2021"
+edition = "2024"
 description = "A library for parsing and extracting files from LHA/LZH archives."
 categories = ["compression"]
 keywords = ["LHA", "LZH", "UNLHA"]
@@ -11,7 +11,7 @@ repository = "https://github.com/royaltm/rust-delharc"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 exclude = [".github", ".gitignore", "tests/*", "examples/*"]
-rust-version = "1.65"
+rust-version = "1.85"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-delharc = "0.6"
+delharc = "0.7"
 ```
 
 For more information, please see the [Documentation][Docs Link].
@@ -44,7 +44,7 @@ external crate will be required instead.
 
 ```toml
 [dependencies.delharc]
-version = "0.6"
+version = "0.7"
 default-features = false
 features = ["lh1", "lz"] # select desired features
 ```
@@ -73,7 +73,7 @@ compression method features.
 Rust Version
 ------------
 
-`delharc` requires Rustc version 1.65 or greater.
+`delharc` requires Rustc version 1.85 or greater - edition 2024.
 
 License
 -------
@@ -100,4 +100,4 @@ at your option.
 [Coverage Link]: https://coveralls.io/github/royaltm/rust-delharc?branch=master
 [Coverage img]: https://coveralls.io/repos/github/royaltm/rust-delharc/badge.svg?branch=master
 [rustc version link]: https://github.com/royaltm/rust-delharc#rust-version
-[rustc version img]: https://img.shields.io/badge/rustc-1.65+-lightgray.svg
+[rustc version img]: https://img.shields.io/badge/rustc-1.85+-lightgray.svg

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ compression method features.
 Rust Version
 ------------
 
-`delharc` requires Rustc version 1.85 or greater - edition 2024.
+`delharc` requires Rustc version 1.93 or greater.
+
 
 License
 -------
@@ -100,4 +101,4 @@ at your option.
 [Coverage Link]: https://coveralls.io/github/royaltm/rust-delharc?branch=master
 [Coverage img]: https://coveralls.io/repos/github/royaltm/rust-delharc/badge.svg?branch=master
 [rustc version link]: https://github.com/royaltm/rust-delharc#rust-version
-[rustc version img]: https://img.shields.io/badge/rustc-1.85+-lightgray.svg
+[rustc version img]: https://img.shields.io/badge/rustc-1.93+-lightgray.svg

--- a/examples/embedded/Cargo.toml
+++ b/examples/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delharc-embedded-example"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Rafał Michalski <royaltm75@gmail.com>"]
 edition = "2021"
 description = "A small example of using delharc with a `no_std` target"
@@ -13,5 +13,5 @@ path="embedded.rs"
 [dependencies]
 delharc = { version = "*", path = "../..", default-features = false, features = ["lh1", "lz"] }
 cortex-m-rt = "0.7"
-panic-halt = "0.2"
-embedded-alloc = "0.5"
+panic-halt = "1.0.0"
+embedded-alloc = "0.7"

--- a/examples/embedded/embedded.rs
+++ b/examples/embedded/embedded.rs
@@ -2,10 +2,9 @@
 #![no_main]
 extern crate alloc;
 use alloc::{format, boxed::Box, vec::Vec};
-use core::mem::MaybeUninit;
 use panic_halt as _;
 use cortex_m_rt::entry;
-use embedded_alloc::Heap;
+use embedded_alloc::LlffHeap as Heap;
 
 use delharc::*;
 
@@ -28,9 +27,9 @@ fn extract_check<R: Read, P: AsRef<str>>(
     where R::Error: core::fmt::Debug
 {
     let mut buf: Box<[u8]> = {
-      let mut vec = Vec::new();
-      vec.resize(UNCOMPRESSED_SIZE, 0u8);
-      vec.into_boxed_slice()
+        let mut vec = Vec::new();
+        vec.resize(UNCOMPRESSED_SIZE, 0u8);
+        vec.into_boxed_slice()
     };
     loop {
         let header = lha_reader.header();
@@ -59,19 +58,15 @@ fn extract_check<R: Read, P: AsRef<str>>(
 
 #[entry]
 fn main() -> ! {
-  {
-      #[no_mangle]
-      static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
-      // FIXME: MRV >= 1.82.0
-      // unsafe { HEAP.init((&raw mut HEAP_MEM) as usize, HEAP_SIZE) }
-      unsafe { HEAP.init(core::ptr::addr_of_mut!(HEAP_MEM) as usize, HEAP_SIZE) }
-  }
+    unsafe {
+        embedded_alloc::init!(HEAP, HEAP_SIZE);
+    }
 
-  let lha_reader = delharc::LhaDecodeReader::new(COMPRESSED_1).unwrap();
-  assert!(extract_check(lha_reader, FILE_MATCH).unwrap());
+    let lha_reader = delharc::LhaDecodeReader::new(COMPRESSED_1).unwrap();
+    assert!(extract_check(lha_reader, FILE_MATCH).unwrap());
 
-  let lha_reader = delharc::LhaDecodeReader::new(COMPRESSED_6).unwrap();
-  assert!(extract_check(lha_reader, FILE_MATCH).unwrap());
+    let lha_reader = delharc::LhaDecodeReader::new(COMPRESSED_6).unwrap();
+    assert!(extract_check(lha_reader, FILE_MATCH).unwrap());
 
-  loop {}
+    loop {}
 }

--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -1,10 +1,9 @@
 //! # Bit-stream tools.
-use core::mem;
 use crate::error::{LhaResult, LhaError};
 use crate::stub_io::Read;
 
 type BitBuf = usize;
-const BITBUF_BYTESIZE: usize = mem::size_of::<BitBuf>();
+const BITBUF_BYTESIZE: usize = size_of::<BitBuf>();
 const BITBUF_BITSIZE: u32 = (BITBUF_BYTESIZE * 8) as u32;
 
 /// The trait is implemented for all the types that can receive bits using [BitRead::read_bits].
@@ -152,7 +151,7 @@ impl<R: Read> BitRead for BitStream<R> {
 
 #[inline(always)]
 const fn bitsize<T>() -> u32 {
-    mem::size_of::<T>() as u32 * 8
+    size_of::<T>() as u32 * 8
 }
 
 #[cfg(feature = "std")]
@@ -162,7 +161,7 @@ mod tests {
     use super::*;
     #[test]
     fn bit_stream_works() {
-        assert_eq!(BITBUF_BYTESIZE, mem::size_of::<usize>());
+        assert_eq!(BITBUF_BYTESIZE, size_of::<usize>());
         assert!(BITBUF_BITSIZE >= 32);
         assert_eq!(BITBUF_BITSIZE, BITBUF_BYTESIZE as u32 * 8);
         let mut somebits: &[u8] = &[];

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -245,10 +245,10 @@ impl<R: Read> LhaDecodeReader<R> where R::Error: fmt::Debug {
     /// Panics when `BUF` = `0`.
     pub fn next_file_with_sink<const BUF: usize>(&mut self) -> Result<bool, LhaDecodeError<R>> {
         let mut limited_rd = self.decoder.take().expect("decoder not empty").into_inner();
-        if limited_rd.limit() != 0 {
-            if let Err(e) = discard_to_end::<_, BUF>(&mut limited_rd).map_err(LhaError::Io) {
-                return Err(wrap_err(limited_rd.into_inner(), e))
-            }
+        if limited_rd.limit() != 0 &&
+            let Err(e) = discard_to_end::<_, BUF>(&mut limited_rd).map_err(LhaError::Io)
+        {
+            return Err(wrap_err(limited_rd.into_inner(), e))
         }
         self.begin_new(limited_rd.into_inner())
     }

--- a/src/decode/lhv1.rs
+++ b/src/decode/lhv1.rs
@@ -136,8 +136,8 @@ mod tests {
 
     #[test]
     fn lhav1_works() {
-        println!("Lh1Decoder<Empty> {}", core::mem::size_of::<Lh1Decoder<io::Empty>>());
-        println!("Lh1Decoder<File> {}", core::mem::size_of::<Lh1Decoder<fs::File>>());
-        println!("DynHuffTree {}", core::mem::size_of::<DynHuffTree>());
+        println!("Lh1Decoder<Empty> {}", size_of::<Lh1Decoder<io::Empty>>());
+        println!("Lh1Decoder<File> {}", size_of::<Lh1Decoder<fs::File>>());
+        println!("DynHuffTree {}", size_of::<DynHuffTree>());
     }
 }

--- a/src/decode/lhv1/dyntree.rs
+++ b/src/decode/lhv1/dyntree.rs
@@ -486,8 +486,8 @@ impl fmt::Display for DynHuffTree {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, RngCore, thread_rng};
-    use rand::distributions::{Uniform, WeightedIndex};
+    use rand::{RngExt, RngReader};
+    use rand::distr::{Uniform, weighted::WeightedIndex};
     use crate::bitstream::BitStream;
     use std::collections::{HashSet, HashMap};
     use super::*;
@@ -590,11 +590,11 @@ mod tests {
         validate_tree(&tree);
         println!("--------------\n{}", tree);
 
-        let mut trng = thread_rng();
+        let mut trng = rand::rng();
         let rng = &mut trng;
         // spam tree with random values
         let mut tree = DynHuffTree::new();
-        for sample in rng.sample_iter(Uniform::new(0, NUM_LEAVES)).take(1_000_000) {
+        for sample in rng.sample_iter(Uniform::new(0, NUM_LEAVES).unwrap()).take(1_000_000) {
             tree.increment_for_value(sample as u16);
         }
         validate_tree(&tree);
@@ -613,8 +613,7 @@ mod tests {
         println!("--------------\n{}", tree);
 
         // now with some random bit stream
-        let rnd_stream: &mut dyn RngCore = rng;
-        let mut rndstream = BitStream::new(rnd_stream);
+        let mut rndstream = BitStream::new(RngReader(rng));
         for _ in 0..1_000_000 {
             tree.read_entry(&mut rndstream).unwrap();
         }

--- a/src/decode/lhv1/dyntree.rs
+++ b/src/decode/lhv1/dyntree.rs
@@ -267,7 +267,7 @@ impl DynHuffTree {
         let mut node_filter = self.nodes.iter().filter(|&n| n.is_leaf());
         let leave_nodes: [(TreeEntry, u16); NUM_LEAVES] = core::array::from_fn(|_| {
             let node = node_filter.next().unwrap();
-            (node.entry, (node.freq + 1) / 2)
+            (node.entry, node.freq.div_ceil(2))
         });
         // an iterator of leaves from last to first
         let mut leaves_riter = leave_nodes.into_iter().rev();
@@ -395,22 +395,20 @@ impl DynHuffTree {
         node.freq += 1;
 
         // node was part of the group with next nodes
-        if let Some(next) = tail.first() {
-            if node.group == next.group {
-                // the next node is now a leader
-                self.groups.set_next_node_as_leader(node.group);
-                if node.freq == prev.freq {
-                    // join group of previous node
-                    node.group = prev.group;
-                }
-                else {
-                    // create node's own group
-                    node.group = self.groups.allocate();
-                    self.groups.set_leader_index(node.group, node_index);
-                }
-
-                return node
+        if let Some(next) = tail.first() && node.group == next.group {
+            // the next node is now a leader
+            self.groups.set_next_node_as_leader(node.group);
+            if node.freq == prev.freq {
+                // join group of previous node
+                node.group = prev.group;
             }
+            else {
+                // create node's own group
+                node.group = self.groups.allocate();
+                self.groups.set_leader_index(node.group, node_index);
+            }
+
+            return node
         }
 
         // node had its own group

--- a/src/decode/lhv2.rs
+++ b/src/decode/lhv2.rs
@@ -308,13 +308,13 @@ mod tests {
 
     #[test]
     fn lhav2_works() {
-        println!("DecoderAny<Empty> {}", core::mem::size_of::<DecoderAny<io::Empty>>());
-        println!("DecoderAny<fs::File> {}", core::mem::size_of::<DecoderAny<fs::File>>());
-        println!("Lh7Decoder<Empty> {}", core::mem::size_of::<Lh7Decoder<io::Empty>>());
-        println!("Lh7Decoder<File> {}", core::mem::size_of::<Lh7Decoder<fs::File>>());
-        println!("BitStream<File> {}", core::mem::size_of::<BitStream<fs::File>>());
-        println!("HuffTree {}", core::mem::size_of::<HuffTree>());
-        println!("Option<(u32, NonZeroU32)> {}", core::mem::size_of::<Option<(u32, NonZeroU32)>>());
-        println!("Box<C::RingBuffer> {}", core::mem::size_of::<Box<<Lh7DecoderCfg as LhaDecoderConfig>::RingBuffer>>());
+        println!("DecoderAny<Empty> {}", size_of::<DecoderAny<io::Empty>>());
+        println!("DecoderAny<fs::File> {}", size_of::<DecoderAny<fs::File>>());
+        println!("Lh7Decoder<Empty> {}", size_of::<Lh7Decoder<io::Empty>>());
+        println!("Lh7Decoder<File> {}", size_of::<Lh7Decoder<fs::File>>());
+        println!("BitStream<File> {}", size_of::<BitStream<fs::File>>());
+        println!("HuffTree {}", size_of::<HuffTree>());
+        println!("Option<(u32, NonZeroU32)> {}", size_of::<Option<(u32, NonZeroU32)>>());
+        println!("Box<C::RingBuffer> {}", size_of::<Box<<Lh7DecoderCfg as LhaDecoderConfig>::RingBuffer>>());
     }
 }

--- a/src/header/compression.rs
+++ b/src/header/compression.rs
@@ -92,6 +92,8 @@ impl fmt::Display for CompressionMethod {
         let strid = self.as_identifier();
         assert!(strid.is_ascii());
         unsafe {
+            // SAFETY: compression identifiers are ASCII-only,
+            // validated with assert above
             core::str::from_utf8_unchecked(strid)
         }.fmt(f)
     }

--- a/src/header/parser.rs
+++ b/src/header/parser.rs
@@ -344,8 +344,7 @@ impl LhaHeader {
                 // read padding byte
                 parser.read_u8()?;
             }
-            else if raw_header.lha_level != 2 ||
-                   (raw_header.lha_level == 2 && long_header_len as usize != parser.len - 2)
+            else if raw_header.lha_level != 2 || long_header_len as usize != parser.len - 2
             {
                 // some packers (Osk) don't include self in the header length
                 return Err(LhaError::HeaderParse("wrong length of headers"))
@@ -353,10 +352,8 @@ impl LhaHeader {
         }
 
         // validate headers CRC
-        if let Some(crc) = header_crc {
-            if crc != parser.crc.sum16() {
-                return Err(LhaError::HeaderParse("wrong header CRC-16 checksum"))
-            }
+        if let Some(crc) = header_crc && crc != parser.crc.sum16() {
+            return Err(LhaError::HeaderParse("wrong header CRC-16 checksum"))
         }
 
         // adjust compressed size for level 1

--- a/src/header/parser.rs
+++ b/src/header/parser.rs
@@ -1,8 +1,9 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::num::Wrapping;
 use core::slice;
 use core::fmt::Write;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use bytemuck::{NoUninit, AnyBitPattern, bytes_of_mut};
 use crate::error::{LhaError, LhaResult};
 use crate::stub_io::Read;
 use crate::crc::Crc16;
@@ -64,7 +65,7 @@ impl<'a> Iterator for ExtraHeaderIter<'a> {
 /// Allocation max for reading with a limit
 const ALLOCATE_LIMIT_MAX: usize = 8*1024;
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, NoUninit, AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 struct LhaRawBaseHeader {
@@ -146,9 +147,8 @@ impl<R: Read> Parser<'_, R> {
             buf.try_reserve_exact(chunk_size).map_err(|_| LhaError::HeaderParse("memory allocation failed"))?;
             // FIXME: use BorrowedBuf once stabilized
             let spare_uninit = &mut buf.spare_capacity_mut()[..chunk_size];
-            // FIXME: use slice::assume_init_mut (MRV >= 1.93)
             // SAFETY: assume read_exact is write-only
-            let spare = unsafe { &mut *(spare_uninit as *mut _ as *mut [u8]) };
+            let spare = unsafe { spare_uninit.assume_init_mut() };
             self.rd.read_exact(spare).map_err(LhaError::Io)?;
             // SAFETY: assume chunk_size was read into buf
             // this can't overflow because buf.len() + chunk_size <= buf.capacity()
@@ -195,10 +195,7 @@ impl LhaHeader {
         parser.csum = Wrapping(0);
 
         let mut raw_header = LhaRawBaseHeader::default();
-        parser.read_exact(unsafe {
-            // SAFETY: safe because LhaRawBaseHeader is packed and contains only byte type members
-            struct_slice_mut(&mut raw_header)
-        })?;
+        parser.read_exact(bytes_of_mut(&mut raw_header))?;
         if raw_header.lha_level > 3 {
             return Err(LhaError::HeaderParse("unknown header level"))
         }
@@ -485,7 +482,8 @@ pub(super) fn parse_str_nilterm(
     {
         let mut out = String::with_capacity(data.len()*3);
         let (head, rest) = data.split_at(index);
-        out.push_str(unsafe { // safe because head was validated
+        // SAFETY: head was validated to contain ASCII-only characters
+        out.push_str(unsafe {
             core::str::from_utf8_unchecked(head)
         });
         for byte in rest.iter() {
@@ -509,19 +507,10 @@ pub(super) fn parse_str_nilterm(
         Cow::Owned(out)
     }
     else {
-        unsafe { // safe because data was validated
+        // SAFETY: data was validated to contain ASCII-only characters
+        unsafe {
             Cow::Borrowed(core::str::from_utf8_unchecked(data))
         }
-    }
-}
-
-/// # Safety
-/// This function can be used safely only with packed structs that solely consist of
-/// `u8` or array of `u8` primitives.
-unsafe fn struct_slice_mut<T: Copy>(obj: &mut T) -> &mut [u8] {
-    let len = core::mem::size_of::<T>() / core::mem::size_of::<u8>();
-    unsafe {
-        core::slice::from_raw_parts_mut(obj as *mut T as *mut u8, len)
     }
 }
 

--- a/src/header/parser.rs
+++ b/src/header/parser.rs
@@ -520,7 +520,9 @@ pub(super) fn parse_str_nilterm(
 /// `u8` or array of `u8` primitives.
 unsafe fn struct_slice_mut<T: Copy>(obj: &mut T) -> &mut [u8] {
     let len = core::mem::size_of::<T>() / core::mem::size_of::<u8>();
-    core::slice::from_raw_parts_mut(obj as *mut T as *mut u8, len)
+    unsafe {
+        core::slice::from_raw_parts_mut(obj as *mut T as *mut u8, len)
+    }
 }
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ You may include or opt out of some of the decoders:
 
 ```toml
 [dependencies.delharc]
-version = "0.6"
+version = "0.7"
 default-features = false
 features = ["std", "lh1"] # select desired features
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,7 @@ pub(crate) mod bitstream;
 pub(crate) mod statictree;
 
 // Various parsers assume usize has enough bits and will break on < 32-bits.
-// FIXME: size_of
-const _: usize = (core::mem::size_of::<usize>() >= core::mem::size_of::<u32>()) as usize - 1;
+const _: usize = (size_of::<usize>() >= size_of::<u32>()) as usize - 1;
 
 pub use decode::LhaDecodeReader;
 pub use header::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ const DATA: &[u8] = include_bytes!("file.lzh");
 let lha_reader = LhaDecodeReader::new(DATA).unwrap();
 ```
 */
-// http://archive.gamedev.net/archive/reference/articles/article295.html
+// https://web.archive.org/web/20240916153830/https://archive.gamedev.net/archive/reference/articles/article295.html
 #![cfg_attr(not(feature = "std"), no_std)]
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/src/statictree.rs
+++ b/src/statictree.rs
@@ -168,7 +168,7 @@ impl HuffTree {
                     let index = index as usize + path.read_bits::<usize>(1)?;
                     debug_assert!(index < tree.len());
                     node = unsafe {
-                        // safe because tree was initialized in a sane way,
+                        // SAFETY: safe because tree was initialized in a sane way,
                         // no outstanding child index has been used
                         tree.get_unchecked(index)
                     };

--- a/src/stub_io.rs
+++ b/src/stub_io.rs
@@ -50,18 +50,14 @@ pub trait Read {
 }
 
 pub(crate) fn discard_to_end<R: Read, const BUF: usize>(rd: &mut R) -> Result<(), R::Error> {
-    use core::mem::{self, MaybeUninit};
+    use core::mem::MaybeUninit;
     assert!(BUF != 0);
-    // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
-    // safe because the type we are claiming to have initialized here is a
-    // bunch of `MaybeUninit`s, which do not require initialization.
-    let mut data: [MaybeUninit<u8>; BUF] = unsafe {
-        MaybeUninit::uninit().assume_init()
-    };
-    let buf = {
-        // TODO: use BorrowedBuf once it stablizes
-        // We never read data and u8 doesn't implement Drop.
-        unsafe { mem::transmute::<_, &mut[u8]>(&mut data[..]) }
+    // FIXME: use BorrowedBuf once it stablizes
+    let mut data = MaybeUninit::<[u8; BUF]>::uninit();
+    let buf: &mut [u8; BUF] = unsafe {
+        // SAFETY: data has not been initialized but is never read,
+        // assuming Read implementation never reads from the buf
+        data.assume_init_mut()
     };
     while 0 != rd.read_all(buf)? {}
     Ok(())

--- a/tests/allocation.rs
+++ b/tests/allocation.rs
@@ -8,14 +8,14 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 static PEAK: AtomicUsize = AtomicUsize::new(0);
 struct Track;
 unsafe impl GlobalAlloc for Track {
-    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 { unsafe {
         PEAK.fetch_max(l.size(), Ordering::Relaxed);
         if l.size() > 512 * 1024 * 1024 {
             return std::ptr::null_mut();
         }
         System.alloc(l)
-    }
-    unsafe fn dealloc(&self, p: *mut u8, l: Layout) { System.dealloc(p, l) }
+    }}
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) { unsafe { System.dealloc(p, l) }}
 }
 
 #[global_allocator]

--- a/tests/regression/README
+++ b/tests/regression/README
@@ -50,3 +50,7 @@ comment.lzh         - Archive created on Amiga with a file note embedded in
 clusterfuzz-1.bin   - A generated file that caused panic in LhaV2Decoder.
                       Sent by @micahsnyder
                       https://github.com/royaltm/rust-delharc/issues/7
+
+fuzz-10-1.bin       - A generated file that caused panic in LhaHeader::read.
+                      Sent by @sylvinus
+                      https://github.com/royaltm/rust-delharc/issues/10


### PR DESCRIPTION
v0.7.0
* Rust edition: 2024.
* Minimum supported rust version changed to Rust 1.93 (slice::assume_init_mut).
* Deps: bitflags bumped to 2.13.
* bytemuck added to dependencies.
* replaced all uses of transmute with modern functions.
* clippy suggested changes.
